### PR TITLE
[251215] 숫자 변환(LV.2, 61%) 풀이 / BFS

### DIFF
--- a/donghun/251215/숫자변환_bfs.java
+++ b/donghun/251215/숫자변환_bfs.java
@@ -1,0 +1,47 @@
+// 풀이 2. 점수 100, 성공
+import java.util.*;
+
+class Solution {
+    int answer = 1_000_001;
+    
+    public int solution(int x, int y, int n) {
+        
+        // 제한 사항 (x,y 1,000,000)
+        
+        // 사용가능한 연산 종류 3가지
+        // 1. x + n 
+        // 2. x * 2
+        // 3. x * 3
+        // 이 3가지 방법을 이용하여 목표 점수로 도달하는
+        // 최소 연산횟수를 리턴 (불가능하다면 -1)
+        
+        // 아 맞다 최단거리는 bfs였지 (queue)
+        // 3가지 연산을 동시에 기록하면서 도달한 값이 있는 경우 종료하도록
+        // [방법1, 방법2, 방법3, count]
+        Queue<int[]> queue = new LinkedList<>();
+        boolean[] visited = new boolean[1_000_001]; // +1 해줘야 1_000_000 까지 도달 가능;
+        queue.add(new int[] {x, 0});
+        
+        while(!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            int value = poll[0];
+            int count = poll[1];
+            
+            if(value == y) return count;
+            
+            // 3가지 연산 수행
+            int[] cal_values = new int[]{value+n, value*2, value*3};
+            
+            for(int i = 0; i < 3; i++) {
+                int pick = cal_values[i];
+                
+                if(pick <= y && !visited[pick]) {
+                    queue.add(new int[]{pick, count+1});
+                    visited[pick] = true; // 방문 처리
+                }
+            }
+        }
+        
+        return -1;
+    }
+}

--- a/donghun/251215/숫자변환_dfs.java
+++ b/donghun/251215/숫자변환_dfs.java
@@ -1,0 +1,40 @@
+// 풀이 1. 점수 50, 시간초과
+import java.util.*;
+
+class Solution {
+    int answer = 1_000_001;
+    
+    public int solution(int x, int y, int n) {
+        
+        // 제한 사항 (x,y 1,000,000)
+        
+        // 사용가능한 연산 종류 3가지
+        // 1. x + n 
+        // 2. x * 2
+        // 3. x * 3
+        // 이 3가지 방법을 이용하여 목표 점수로 도달하는
+        // 최소 연산횟수를 리턴 (불가능하다면 -1)
+        
+        // dfs로 모든 방법 탐색?
+        
+        dfs(x, y, n, 0);
+        
+        return answer == 1_000_001 ? -1 : answer;
+    }
+    
+    // 3가지 방법으로 계산해나가는 dfs
+    // current (현재 상태), target (목표 자연수), cal(연산해야하는 값)
+    // n(1번 방법), count(누적 count)
+    private void dfs(int current, int target, int n, int count) {
+        if(current == target) { // 목표값 도달 시, count 최솟값 기록
+            answer = Math.min(answer, count);
+        } else if (current < target){ // 아직 도달하지 못했을 때
+            // 1번 방법
+            dfs(current+n, target, n, count+1);
+            // 2번 방법
+            dfs(current*2, target, n, count+1);
+            // 3번 방법
+            dfs(current*3, target, n, count+1);
+        }   
+    }
+}


### PR DESCRIPTION
# 🎯 정답 제출
#172 

## 📝 한마디
<!-- 해결한 문제에 대한 간단한 한 줄 요약을 작성해주세요 -->
의도하진 않았지만 dfs/bfs 문제를 내버렸다. (dfs 뭔가 금방금방 짜지는 느낌)

## ✅ 해결한 문제 목록
<!-- 해결한 문제들을 체크해주세요 -->
- [x] 문제 1: 숫자 변환(LV.2, 61%)

## 💻 코드 설명
<!-- 작성한 코드에 대한 설명을 작성해주세요 -->
- Queue와 visited 방문 배열을 이용해 queue에서 꺼낸 값이 목표값에 도달하지 못했다면 3가지 연산 처리를 수행하고 다시 큐에 삽입함
- 이 때, 3가지 연산이 수행된 값은 방문처리를 하여 중복처리하지 않도록 함

### 접근 방법
<!-- 문제를 해결하기 위해 어떤 접근 방법을 사용했는지 설명해주세요 -->
## 1. dfs
- 1,000,000 의 큰 숫자 때문에 너무 많은 호출이 발생해 실패
- 하지만 시간만 충분하다면 맞는 로직 (시간초과)

## 2.dfs
- "최소 연산횟수" 키워드에서 bfs를 떠올려야했음.

### 알고리즘/로직
<!-- 사용한 알고리즘이나 핵심 로직을 설명해주세요 -->
- dfs/bfs

## 🤔 어려웠던 점
<!-- 문제를 해결하면서 어려웠던 점이나 고민했던 부분을 작성해주세요 -->

## 💡 개선 사항
<!-- 코드를 더 개선할 수 있는 부분이나 다른 접근 방법이 있다면 작성해주세요 -->

## 📸 실행 결과
<!-- 코드 실행 결과나 스크린샷이 있다면 첨부해주세요 -->
<img width="553" height="562" alt="image" src="https://github.com/user-attachments/assets/c63167e6-57ae-490f-8fea-67133f27c706" />


## 📝 추가 정보
<!-- 기타 리뷰어가 알아야 할 정보가 있다면 작성해주세요 -->
- 아까 dfs에 visited[] 배열을 이용해서 개선하는 방법을 시도해보겠다고 말씀드리고, 한번 해보았는데 dfs특성상 모든 노드를 탐색하기 때문에 불가능했습니다 ㅠ-ㅠ
